### PR TITLE
Swift 5.2 migration

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "Quick/Quick" "v2.1.0"
 github "Quick/Nimble" "v8.0.1"
-github "DomainGroupOSS/swift-snapshot-testing" "2.0.0"
+github "DomainGroupOSS/swift-snapshot-testing" "task/swift5.2-fix"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "Quick/Quick" "v2.1.0"
 github "Quick/Nimble" "v8.0.1"
-github "DomainGroupOSS/swift-snapshot-testing" "task/swift5.2-fix"
+github "DomainGroupOSS/swift-snapshot-testing" "2.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "DomainGroupOSS/swift-snapshot-testing" "2.0.0"
+github "DomainGroupOSS/swift-snapshot-testing" "1d68045ecc3880e98ef3f50fceace242e844d5ec"
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "DomainGroupOSS/swift-snapshot-testing" "1d68045ecc3880e98ef3f50fceace242e844d5ec"
+github "DomainGroupOSS/swift-snapshot-testing" "2.1.0"
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.1.0"


### PR DESCRIPTION
Current `master` is up to date with our tagged releases so targetting that in this PR