### PR TITLE
Xcode12 preparation: Move test framework dependencies back to original upstream

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Quick/Quick" "v2.1.0"
-github "Quick/Nimble" "v8.0.1"
-github "DomainGroupOSS/swift-snapshot-testing" "2.1.0"
+github "Quick/Nimble" "v8.1.2"
+github "pointfreeco/swift-snapshot-testing" ~> 1.8.2
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "DomainGroupOSS/swift-snapshot-testing" "2.1.0"
-github "Quick/Nimble" "v8.0.1"
+github "Quick/Nimble" "v8.1.2"
 github "Quick/Quick" "v2.1.0"
+github "pointfreeco/swift-snapshot-testing" "1.8.2"

--- a/SnapshotTesting-Nimble.xcodeproj/project.pbxproj
+++ b/SnapshotTesting-Nimble.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "SnapshotTesting-Nimble/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -535,6 +536,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "SnapshotTesting-Nimble/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "au.com.domain.group.SnapshotTesting-Nimble";


### PR DESCRIPTION
See title.